### PR TITLE
Rename reserva DTO property for frontend compatibility

### DIFF
--- a/Gimnasio.Api/DTOs/ReservaDto.cs
+++ b/Gimnasio.Api/DTOs/ReservaDto.cs
@@ -12,7 +12,7 @@ namespace Gimnasio.Api.DTOs
         public int SocioId { get; set; }
         public int ClaseId { get; set; }
         public DateTime FechaReserva { get; set; }
-        public DateTime z { get; set; }
+        public DateTime FechaClase { get; set; }
         public string? SocioNombreCompleto { get; set; }
         public string? ClaseNombre { get; set; }
     }


### PR DESCRIPTION
## Summary
- rename the `ReservaDto` property from `z` to `FechaClase` so the API payload aligns with the frontend expectations

## Testing
- dotnet build *(fails: `dotnet: command not found` in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_690cef3d0f6083338df024ea4bbba324